### PR TITLE
[JENKINS-72161] avoid inodes check takes agents online

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/inodesnodemonitor/InodesMonitor/column.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/inodesnodemonitor/InodesMonitor/column.jelly
@@ -2,10 +2,19 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
-      <td align="middle" data="-1">${%N/A}</td>
+      <td align="right" data="-1">${%N/A}</td>
     </j:when>
     <j:otherwise>
-      <td align="middle">${data}</td>
+      <td align="right">
+        <j:choose>
+          <j:when test="${data.triggered}">
+            <span class="error" tooltip="${data.toString()}">${data.usage}</span>
+          </j:when>
+          <j:otherwise>
+            ${data.usage}
+          </j:otherwise>
+        </j:choose>
+      </td>
     </j:otherwise>
   </j:choose>
 

--- a/src/main/resources/org/jenkinsci/plugins/inodesnodemonitor/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/inodesnodemonitor/Messages.properties
@@ -3,3 +3,4 @@ inodesmonitor.notapplicable.onerror=N/A (error)
 inodesmonitor.useinpercent=Used Inodes 
 inodesmonitor.markedOffline=Node {0} has been put offline because inodes usage threshold was reached ({1}) 
 inodesmonitor.markedOnline=Node {0} has been put online (inodes usage: {1})
+inodesmonitor.FreeInodesTooLow=Inodes usage threshold was reached (current={0}, threshold={1})


### PR DESCRIPTION
also JENKINS-72160

Use an OfflineCause specific to the Inodes usage when taking an agent offline and check before taking an agent online if the current cause is an Inodes cause. If not it wasn't the plugin that took the agent offline, thus it needs to stay offline.

Use the cause as data object so we can highlight the table cell when agent is offline. This will also show a tooltip with the threshold.

<!-- Please describe your pull request here. -->

### Testing done
Manually tested that agents that were taken offline manually stay offline.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
