### PR TITLE
reduce log output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/inodesnodemonitor/DfRunner.java
+++ b/src/main/java/org/jenkinsci/plugins/inodesnodemonitor/DfRunner.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class DfRunner {
@@ -31,7 +32,7 @@ class DfRunner {
         for (Map.Entry<String, DfCommand> impl : IMPLEMENTATIONS.entrySet()) {
             final String key = impl.getKey();
             if(osName.toLowerCase().startsWith(key)) {
-				LOGGER.info("DfRunner implementation key selected: " + key);
+				LOGGER.fine(() -> "DfRunner implementation key selected: " + key);
 				return impl.getValue();
             }
         }
@@ -50,7 +51,7 @@ class DfRunner {
 
 		public String get() {
 			try {
-				LOGGER.fine("Inodes monitoring: running '" + command + "' command in " + System.getProperty("user.dir"));
+				LOGGER.finer(() -> "Inodes monitoring: running '" + command + "' command in " + System.getProperty("user.dir"));
 				Process process = Runtime.getRuntime().exec(command);
 				// Encoding used below could be many ones, as anyway the charset expect for df output is encoded the same in US_ASCII or UTF8 for instance
 				// /me sighs at that confusion between charsets and [character] encoding[s] schemes.
@@ -62,13 +63,13 @@ class DfRunner {
 					if (values == null) {
 						return Messages.inodesmonitor_notapplicable_onerror();
 					}
-					LOGGER.warning("df values output: " + values);
-                    String[] split = values.split(" +");
-                    return split[column - 1];
-                }
+					LOGGER.fine(() -> "df values output: " + values);
+					String[] split = values.split(" +");
+					return split[column - 1];
+				}
 			}
 			catch (IOException e) {
-				LOGGER.fine("Error while running '" + command + "'");
+				LOGGER.log(Level.WARNING, e, () -> "Error while running '" + command + "'");
 				return Messages.inodesmonitor_notapplicable_onerror();
 			}
 		}


### PR DESCRIPTION
each time the df command runs it prints 2 commands to the log of an agent. This is unncecessary and spams the log with no useful information.
And when an error occurs then it was only logged as fine instead of warning.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
